### PR TITLE
Update Circle Config for Node 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
       - run: npm install
       - run: npm i --prefix=$HOME/.local @cloudflare/wrangler@1.19.3 -g
       - run: 
-          command: <<parameters.node-args>> run test && run test:integration
+          command: <<parameters.node-args>> run test && <<parameters.node-args>> run test:integration
       - when:
           condition: <<parameters.run-lint>>
           steps:


### PR DESCRIPTION
Ticket: sc-127494

Update Circle CI config so we pass in legacy SSL options for Node 17. This is coming from Wrangler `wranglerjs-1.19.3` once that gets updated we should be able to remove this.